### PR TITLE
Add Flask OpenCV demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # WareEye
+
+This repository contains a simple OpenCV application served through a Flask web interface.
+
+## Setup
+
+Install the required dependencies using `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the App
+
+Start the Flask development server:
+
+```bash
+python app.py
+```
+
+Open your browser and navigate to `http://localhost:5000`. Upload an image to see the grayscale result generated with OpenCV.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,38 @@
+import cv2
+import numpy as np
+from flask import Flask, request, render_template_string, send_file
+from io import BytesIO
+
+app = Flask(__name__)
+
+INDEX_HTML = '''
+<!doctype html>
+<title>OpenCV Flask App</title>
+<h1>Upload an image to convert to grayscale</h1>
+<form method=post enctype=multipart/form-data action="/process">
+  <input type=file name=file>
+  <input type=submit value=Upload>
+</form>
+'''
+
+@app.route('/')
+def index():
+    return render_template_string(INDEX_HTML)
+
+@app.route('/process', methods=['POST'])
+def process():
+    file = request.files.get('file')
+    if not file:
+        return "No file uploaded", 400
+
+    file_bytes = np.frombuffer(file.read(), np.uint8)
+    img = cv2.imdecode(file_bytes, cv2.IMREAD_COLOR)
+    if img is None:
+        return "Invalid image", 400
+
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    _, buf = cv2.imencode('.png', gray)
+    return send_file(BytesIO(buf.tobytes()), mimetype='image/png')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+opencv-python-headless


### PR DESCRIPTION
## Summary
- add a Flask app that converts uploaded images to grayscale using OpenCV
- include Flask and OpenCV dependencies
- document setup and running instructions

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- `python app.py` *(fails: server only runs interactively but starts successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6871d6d38e508327b827acdb87e300c7