### PR TITLE
Add camera navigation links

### DIFF
--- a/app/routes/detector.py
+++ b/app/routes/detector.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, Response, render_template_string
+from flask import Blueprint, Response, render_template
 from ..services.detector_service import (
     frames,
     start as start_detection,
@@ -8,19 +8,9 @@ from ..services.detector_service import (
 
 bp = Blueprint('detector', __name__)
 
-INDEX_HTML = """
-<!doctype html>
-<title>WareEye Stream</title>
-<h1>Live Pallet Barcode Detection</h1>
-<img id=\"feed\" src=\"/video_feed\" width=\"720\"/>
-<br>
-<button onclick=\"fetch('/start')\">Start</button>
-<button onclick=\"fetch('/stop')\">Stop</button>
-"""
-
 @bp.route('/')
 def index():
-    return render_template_string(INDEX_HTML)
+    return render_template('index.html')
 
 
 def generate():

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,8 +2,9 @@
 <title>WareEye</title>
 <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 <nav class="bg-gray-800 p-4 text-white">
-  <a href="/" class="mr-4">Home</a>
-  <a href="/cameras" class="mr-4">Cameras</a>
+  <a href="{{ url_for('detector.index') }}" class="mr-4">Home</a>
+  <a href="{{ url_for('cameras.list_cameras') }}" class="mr-4">Camera List</a>
+  <a href="{{ url_for('cameras.new_camera_form') }}" class="mr-4">Add Camera</a>
 </nav>
 <div class="p-4">
   {% block content %}{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="text-xl font-bold mb-4">Live Pallet Barcode Detection</h1>
+<img id="feed" src="{{ url_for('detector.video_feed') }}" width="720"/>
+<div class="mt-2">
+  <button onclick="fetch('{{ url_for('detector.start') }}')" class="bg-blue-600 text-white px-4 py-1 mr-2">Start</button>
+  <button onclick="fetch('{{ url_for('detector.stop') }}')" class="bg-red-600 text-white px-4 py-1">Stop</button>
+</div>
+<div class="mt-4 space-x-2">
+  <a href="{{ url_for('cameras.list_cameras') }}" class="bg-gray-800 text-white px-3 py-1">View Cameras</a>
+  <a href="{{ url_for('cameras.new_camera_form') }}" class="bg-gray-800 text-white px-3 py-1">Add Camera</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- link to camera pages in the shared navbar
- convert the home page to a template and add camera buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68733a0b40d08327a8bfbf74fa54a494