### PR TITLE
Compute camera stream URL automatically

### DIFF
--- a/app/models/camera.py
+++ b/app/models/camera.py
@@ -1,12 +1,21 @@
 from dataclasses import dataclass
 from typing import Optional
 
+
+def build_url(ip: str, password: str) -> str:
+    """Construct the RTSP URL for the camera."""
+    return f"rtsp://admin:{password}@{ip}:554/h264Preview_01_main"
+
 @dataclass
 class Camera:
     id: Optional[int]
     name: str
     zone: str
     ip_address: str
-    url: str
     password: str
     scanning: bool = False
+    url: str = ""
+
+    def __post_init__(self) -> None:
+        # Automatically build the stream URL based on IP and password
+        self.url = build_url(self.ip_address, self.password)

--- a/app/routes/cameras.py
+++ b/app/routes/cameras.py
@@ -20,7 +20,6 @@ def create_camera():
         request.form.get('name', ''),
         request.form.get('zone', ''),
         request.form.get('ip_address', ''),
-        request.form.get('url', ''),
         request.form.get('password', ''),
         scanning,
     )
@@ -42,7 +41,6 @@ def update_camera(camera_id: int):
         request.form.get('name', ''),
         request.form.get('zone', ''),
         request.form.get('ip_address', ''),
-        request.form.get('url', ''),
         request.form.get('password', ''),
         scanning,
     )

--- a/app/services/camera_service.py
+++ b/app/services/camera_service.py
@@ -1,6 +1,8 @@
 import sqlite3
 from typing import Dict, List, Optional
 
+from ..models.camera import build_url
+
 DB_PATH = "cameras.db"
 
 
@@ -59,7 +61,9 @@ def get(camera_id: int) -> Optional[Dict]:
     return _row_to_dict(row) if row else None
 
 
-def create(name: str, zone: str, ip_address: str, url: str, password: str, scanning: bool = False) -> None:
+def create(name: str, zone: str, ip_address: str, password: str, scanning: bool = False) -> None:
+    """Create a new camera and generate its stream URL."""
+    url = build_url(ip_address, password)
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute(
@@ -70,7 +74,9 @@ def create(name: str, zone: str, ip_address: str, url: str, password: str, scann
     conn.close()
 
 
-def update(camera_id: int, name: str, zone: str, ip_address: str, url: str, password: str, scanning: bool = False) -> None:
+def update(camera_id: int, name: str, zone: str, ip_address: str, password: str, scanning: bool = False) -> None:
+    """Update an existing camera, regenerating its URL."""
+    url = build_url(ip_address, password)
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute(

--- a/templates/cameras/form.html
+++ b/templates/cameras/form.html
@@ -5,7 +5,6 @@
   <label class="block">Name:<input class="border" type="text" name="name" value="{{ camera.name if camera else '' }}" required></label>
   <label class="block">Zone:<input class="border" type="text" name="zone" value="{{ camera.zone if camera else '' }}"></label>
   <label class="block">IP Address:<input class="border" type="text" name="ip_address" value="{{ camera.ip_address if camera else '' }}"></label>
-  <label class="block">URL:<input class="border" type="text" name="url" value="{{ camera.url if camera else '' }}"></label>
   <label class="block">Password:<input class="border" type="password" name="password" value="{{ camera.password if camera else '' }}"></label>
   <label class="block">Scanning:
     <input type="checkbox" name="scanning" {% if camera and camera.scanning %}checked{% endif %}>


### PR DESCRIPTION
## Summary
- add `build_url` helper and automatically compute the camera RTSP URL
- regenerate the URL whenever a camera is created or updated
- drop URL field from the add/edit form

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687419e3d7c88327aba5c42b825af534