### PR TITLE
Add dynamic camera streaming pages

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,7 @@
+from . import camera_service, barcode_service, ip_camera_service
+
+__all__ = [
+    'camera_service',
+    'barcode_service',
+    'ip_camera_service',
+]

--- a/app/services/ip_camera_service.py
+++ b/app/services/ip_camera_service.py
@@ -1,0 +1,20 @@
+import cv2
+from typing import Generator
+
+
+def frames(url: str) -> Generator[bytes, None, None]:
+    """Yield JPEG-encoded frames from the given stream URL."""
+    cap = cv2.VideoCapture(url)
+    if not cap.isOpened():
+        return
+    try:
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                continue
+            ret, buf = cv2.imencode('.jpg', frame)
+            if not ret:
+                continue
+            yield buf.tobytes()
+    finally:
+        cap.release()

--- a/templates/cameras/list.html
+++ b/templates/cameras/list.html
@@ -19,7 +19,8 @@
     <td class="px-2 py-1">{{ cam.url }}</td>
     <td class="px-2 py-1">{{ 'Yes' if cam.scanning else 'No' }}</td>
     <td class="px-2 py-1">
-      <a class="text-blue-600" href="{{ url_for('cameras.edit_camera_form', camera_id=cam.id) }}">Edit</a>
+      <a class="text-blue-600 mr-2" href="{{ url_for('cameras.view_camera', camera_id=cam.id) }}">View</a>
+      <a class="text-blue-600 mr-2" href="{{ url_for('cameras.edit_camera_form', camera_id=cam.id) }}">Edit</a>
       <form action="{{ url_for('cameras.delete_camera', camera_id=cam.id) }}" method="post" style="display:inline;">
         <button class="text-red-600" type="submit" onclick="return confirm('Delete camera?');">Delete</button>
       </form>

--- a/templates/cameras/view.html
+++ b/templates/cameras/view.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="text-xl font-bold mb-4">{{ camera.name }}</h1>
+<img src="{{ url_for('cameras.video_feed', camera_id=camera.id) }}" width="720" />
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement generic IP camera frame generator
- expose camera view and streaming routes
- link to camera stream from camera list
- add template for viewing a camera

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68743a2618f4832790a27d4329bb2ca2