### PR TITLE
Add scanning toggle button

### DIFF
--- a/app/routes/cameras.py
+++ b/app/routes/cameras.py
@@ -61,6 +61,15 @@ def view_camera(camera_id: int):
     return render_template('cameras/view.html', camera=camera)
 
 
+@bp.route('/<int:camera_id>/toggle_scanning', methods=['POST'])
+def toggle_scanning(camera_id: int):
+    """Toggle the scanning state for the given camera."""
+    new_state = camera_service.toggle_scanning(camera_id)
+    if new_state is None:
+        return 'Camera not found', 404
+    return redirect(url_for('cameras.view_camera', camera_id=camera_id))
+
+
 def _stream_generator(url: str):
     for frame in ip_camera_service.frames(url):
         yield b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + frame + b"\r\n"

--- a/app/services/camera_service.py
+++ b/app/services/camera_service.py
@@ -95,3 +95,22 @@ def delete(camera_id: int) -> None:
     c.execute("DELETE FROM cameras WHERE id=?", (camera_id,))
     conn.commit()
     conn.close()
+
+
+def toggle_scanning(camera_id: int) -> Optional[bool]:
+    """Toggle the scanning flag for a camera and return the new state.
+
+    Returns ``None`` if the camera does not exist."""
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("SELECT scanning FROM cameras WHERE id=?", (camera_id,))
+    row = c.fetchone()
+    if row is None:
+        conn.close()
+        return None
+
+    new_value = 0 if row[0] else 1
+    c.execute("UPDATE cameras SET scanning=? WHERE id=?", (new_value, camera_id))
+    conn.commit()
+    conn.close()
+    return bool(new_value)

--- a/templates/cameras/view.html
+++ b/templates/cameras/view.html
@@ -2,4 +2,8 @@
 {% block content %}
 <h1 class="text-xl font-bold mb-4">{{ camera.name }}</h1>
 <img src="{{ url_for('cameras.video_feed', camera_id=camera.id) }}" width="720" />
+<p class="mt-2">Scanning: {{ 'Yes' if camera.scanning else 'No' }}</p>
+<form class="mt-2" action="{{ url_for('cameras.toggle_scanning', camera_id=camera.id) }}" method="post">
+  <button class="bg-blue-600 text-white px-4 py-1" type="submit">Scan</button>
+</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- toggle scanning flag for cameras
- add route to flip scanning state
- show scanning status and Scan button on view page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687440fee96c83278cd5ea8c3b6e2346