### PR TITLE
Inline Flask startup logic in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,19 @@
-from app import create_app
+"""Application entrypoint for WareEye."""
 
-app = create_app()
+from flask import Flask
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+from app.services import camera_service, barcode_service
+from app.routes import cameras
+
+
+# Initialize storage backends on startup
+camera_service.init_db()
+barcode_service.init_db()
+
+
+app = Flask(__name__)
+app.register_blueprint(cameras.bp)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,15 +1,6 @@
-from flask import Flask
-from .services import camera_service, barcode_service
+"""WareEye application package."""
 
+# Re-export commonly used services for convenience
+from .services import camera_service, barcode_service  # noqa: F401
 
-def create_app() -> Flask:
-    camera_service.init_db()
-    barcode_service.init_db()
-
-    app = Flask(__name__, template_folder="../templates")
-
-    from .routes import cameras
-
-    app.register_blueprint(cameras.bp)
-
-    return app
+__all__ = ["camera_service", "barcode_service"]


### PR DESCRIPTION
## Summary
- inline Flask initialization and blueprint registration in `app.py`
- simplify `app/__init__.py` now that startup lives in `app.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `./start-services.sh` *(fails until libzbar is installed, then runs)*

------
https://chatgpt.com/codex/tasks/task_e_687a76b121208327b44c57082348a95a