### PR TITLE
Separate scanning client from Flask server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # WareEye
 
-WareEye provides a simple Flask interface for managing IP cameras and logging
-any barcodes detected in real time.
+WareEye now separates the server that stores barcode scans from the client that
+performs the actual decoding.  The Flask server only receives scan messages and
+provides a web interface for viewing cameras and stored scans.
 
 ## Setup
 
@@ -11,7 +12,8 @@ Install the required dependencies using `pip`:
 pip install -r requirements.txt
 ```
 
-The requirements include `pyzbar` for decoding barcodes.
+The server no longer performs barcode decoding so only the minimal
+dependencies are required.
 
 ## Running the App
 
@@ -21,7 +23,24 @@ Start the services using the provided script:
 ./start-services.sh
 ```
 
+
 Then open your browser and navigate to `http://localhost:5000/cameras` to manage your cameras.
+
+### Client Scanner
+
+The `client/` directory contains a standalone script that connects to a camera,
+decodes barcodes and posts them to the server using `/api/scans`. Install its
+dependencies with:
+
+```bash
+pip install -r client/requirements.txt
+```
+
+Run the scanner by providing the camera RTSP URL:
+
+```bash
+python client/scanner.py --camera-url rtsp://<ip>/path
+```
 
 
 ## Project Structure
@@ -31,4 +50,5 @@ Then open your browser and navigate to `http://localhost:5000/cameras` to manage
 - `app/models/` – data class definitions
 - `templates/` – Jinja2 templates organized by feature
 - `static/` – static assets (Tailwind via CDN)
+- `client/` – standalone barcode scanner that posts results to the server
 

--- a/app/models/camera.py
+++ b/app/models/camera.py
@@ -13,7 +13,6 @@ class Camera:
     zone: str
     ip_address: str
     password: str
-    scanning: bool = False
     url: str = ""
 
     def __post_init__(self) -> None:

--- a/app/services/ip_camera_service.py
+++ b/app/services/ip_camera_service.py
@@ -1,11 +1,5 @@
 import cv2
-import threading
-from typing import Generator, Dict
-from pyzbar.pyzbar import decode, ZBarSymbol
-
-from . import barcode_service
-
-_scanner_threads: Dict[int, threading.Event] = {}
+from typing import Generator
 
 
 def frames(url: str) -> Generator[bytes, None, None]:
@@ -26,39 +20,3 @@ def frames(url: str) -> Generator[bytes, None, None]:
         cap.release()
 
 
-def _scan_loop(url: str, stop_event: threading.Event) -> None:
-    """Continuously capture frames from the IP camera and decode QR codes."""
-    cap = cv2.VideoCapture(url)
-    if not cap.isOpened():
-        return
-    try:
-        while not stop_event.is_set():
-            ret, frame = cap.read()
-            if not ret:
-                continue
-            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-            for code in decode(gray, symbols=[ZBarSymbol.QRCODE]):
-                try:
-                    text = code.data.decode("utf-8")
-                except Exception:
-                    continue
-                barcode_service.save_scan(text)
-    finally:
-        cap.release()
-
-
-def start_scanning(camera_id: int, url: str) -> None:
-    """Start a background scanning thread for the given camera if not running."""
-    if camera_id in _scanner_threads:
-        return
-    stop_event = threading.Event()
-    thread = threading.Thread(target=_scan_loop, args=(url, stop_event), daemon=True)
-    _scanner_threads[camera_id] = stop_event
-    thread.start()
-
-
-def stop_scanning(camera_id: int) -> None:
-    """Stop the scanning thread for the given camera if it exists."""
-    event = _scanner_threads.pop(camera_id, None)
-    if event:
-        event.set()

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,3 +1,4 @@
-Flask
 opencv-python-headless
 numpy
+pyzbar
+requests

--- a/client/scanner.py
+++ b/client/scanner.py
@@ -1,0 +1,38 @@
+import argparse
+import cv2
+from pyzbar.pyzbar import decode, ZBarSymbol
+import requests
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Barcode scanning client")
+    parser.add_argument("--camera-url", required=True, help="RTSP URL of the camera")
+    parser.add_argument("--server", default="http://localhost:5000", help="WareEye server base URL")
+    args = parser.parse_args()
+
+    cap = cv2.VideoCapture(args.camera_url)
+    if not cap.isOpened():
+        print("Failed to open camera stream")
+        return
+
+    try:
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                continue
+            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            for code in decode(gray, symbols=[ZBarSymbol.QRCODE]):
+                try:
+                    text = code.data.decode("utf-8")
+                except Exception:
+                    continue
+                try:
+                    requests.post(f"{args.server}/api/scans", json={"code": text}, timeout=1)
+                except Exception as e:
+                    print(f"Failed to send scan: {e}")
+    finally:
+        cap.release()
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,11 +1,6 @@
 <!doctype html>
 <title>WareEye</title>
 <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-<style>
-  .scan-success {
-    background-color: #38a169;
-  }
-</style>
 <nav class="bg-gray-800 p-4 text-white">
   <a href="{{ url_for('cameras.list_cameras') }}" class="mr-4">Camera List</a>
   <a href="{{ url_for('cameras.new_camera_form') }}" class="mr-4">Add Camera</a>

--- a/templates/cameras/form.html
+++ b/templates/cameras/form.html
@@ -6,9 +6,6 @@
   <label class="block">Zone:<input class="border" type="text" name="zone" value="{{ camera.zone if camera else '' }}"></label>
   <label class="block">IP Address:<input class="border" type="text" name="ip_address" value="{{ camera.ip_address if camera else '' }}"></label>
   <label class="block">Password:<input class="border" type="password" name="password" value="{{ camera.password if camera else '' }}"></label>
-  <label class="block">Scanning:
-    <input type="checkbox" name="scanning" {% if camera and camera.scanning %}checked{% endif %}>
-  </label>
   <button class="bg-blue-600 text-white px-4 py-1" type="submit">Save</button>
   <a class="text-gray-600" href="{{ url_for('cameras.list_cameras') }}">Cancel</a>
 </form>

--- a/templates/cameras/list.html
+++ b/templates/cameras/list.html
@@ -8,7 +8,6 @@
     <th class="px-2 py-1">Zone</th>
     <th class="px-2 py-1">IP Address</th>
     <th class="px-2 py-1">URL</th>
-    <th class="px-2 py-1">Scanning</th>
     <th class="px-2 py-1">Actions</th>
   </tr>
   {% for cam in cameras %}
@@ -17,7 +16,6 @@
     <td class="px-2 py-1">{{ cam.zone }}</td>
     <td class="px-2 py-1">{{ cam.ip_address }}</td>
     <td class="px-2 py-1">{{ cam.url }}</td>
-    <td class="px-2 py-1">{{ 'Yes' if cam.scanning else 'No' }}</td>
     <td class="px-2 py-1">
       <a class="text-blue-600 mr-2" href="{{ url_for('cameras.view_camera', camera_id=cam.id) }}">View</a>
       <a class="text-blue-600 mr-2" href="{{ url_for('cameras.edit_camera_form', camera_id=cam.id) }}">Edit</a>

--- a/templates/cameras/view.html
+++ b/templates/cameras/view.html
@@ -17,38 +17,6 @@
   {% endfor %}
 </table>
 
-<script>
-  const cameraId = {{ camera.id }};
-  let lastTs = {{ last_timestamp }};
-
-  function start() {
-    fetch(`/cameras/${cameraId}/start_scan`, {method: 'POST'});
-  }
-
-  function stop() {
-    fetch(`/cameras/${cameraId}/stop_scan`, {method: 'POST', keepalive: true});
-  }
-
-  function checkForScans() {
-    fetch(`{{ url_for('cameras.last_scan_timestamp') }}`)
-      .then(r => r.json())
-      .then(data => {
-        if (data.timestamp > lastTs) {
-          lastTs = data.timestamp;
-          document.body.classList.add('scan-success');
-          setTimeout(() => {
-            document.body.classList.remove('scan-success');
-          }, 1500);
-        }
-      });
-  }
-
-  window.addEventListener('load', () => {
-    start();
-    setInterval(checkForScans, 1000);
-  });
-  window.addEventListener('beforeunload', stop);
-</script>
 
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove scanning logic from server
- simplify camera model and service
- update camera routes and templates
- add API to accept posted scans
- create `client` folder with standalone scanner script
- document new server/client workflow

## Testing
- `python -m py_compile app.py app/services/*.py app/routes/*.py client/scanner.py`

------
https://chatgpt.com/codex/tasks/task_e_687a7e367b8483279ba9730da6543256