### PR TITLE
Add configurable YOLO model path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# WareEye
+
+Simple client and server utilities for barcode and QR code detection.
+
+## Installation
+
+Install dependencies for the client:
+
+```bash
+pip install -r Client/requirements.txt
+```
+
+## Usage
+
+Run the camera stream script. By default it looks for a YOLO model named `barcode_yolo.pt` in the current working directory. You can specify a different path either via a command line argument or environment variable.
+
+```bash
+# Using a command line argument
+python Client/security_camera_stream.py --model-path /path/to/barcode_yolo.pt
+
+# Or via environment variable
+export YOLO_MODEL_PATH=/path/to/barcode_yolo.pt
+python Client/security_camera_stream.py
+```


### PR DESCRIPTION
## Summary
- allow providing YOLO model path via `--model-path` or `YOLO_MODEL_PATH`
- warn if the YOLO model file is missing instead of failing
- document usage of the new option in README

## Testing
- `python -m py_compile Client/security_camera_stream.py`

------
https://chatgpt.com/codex/tasks/task_e_687ae36498648327906f2b88f1e96097