### PR TITLE
Add barcode API sending

### DIFF
--- a/Client/requirements.txt
+++ b/Client/requirements.txt
@@ -1,3 +1,4 @@
 opencv-contrib-python==4.12.0.88
 pyzbar==0.1.9
 ultralytics==8.3.168
+requests==2.31.0

--- a/Server/app.py
+++ b/Server/app.py
@@ -1,10 +1,17 @@
-from flask import Flask
+from flask import Flask, request, jsonify
 
 app = Flask(__name__)
 
 @app.route('/')
 def hello():
     return 'Hello, World from Flask!'
+
+
+@app.route('/scan', methods=['POST'])
+def scan():
+    data = request.get_json(force=True, silent=True) or {}
+    print(f"Received payload: {data}")
+    return jsonify({'status': 'ok'})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add functions to send barcode scans to a configured server
- store camera info into a file and read it when sending
- implement simple `/scan` endpoint on server
- add `requests` dependency for the client

## Testing
- `python -m py_compile Client/security_camera_stream.py Server/app.py`

------
https://chatgpt.com/codex/tasks/task_e_687bf4fd18cc83278fb3347de0a72964