### PR TITLE
Implement Scan ingestion and CRUD UI

### DIFF
--- a/Server/app.py
+++ b/Server/app.py
@@ -1,17 +1,120 @@
-from flask import Flask, request, jsonify
+"""Simple Flask application for barcode scan ingestion and CRUD UI."""
+
+from datetime import datetime
+
+from flask import (
+    Flask,
+    request,
+    jsonify,
+    render_template,
+    redirect,
+    url_for,
+    flash,
+    Blueprint,
+)
+from flask_sqlalchemy import SQLAlchemy
+from flask_cors import CORS
 
 app = Flask(__name__)
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///app.db"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+app.config["SECRET_KEY"] = "dev"
+db = SQLAlchemy(app)
+CORS(app)
+
+class Scan(db.Model):
+    """Database model for a scan event."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    camera_name = db.Column(db.String, nullable=False)
+    area = db.Column(db.String, nullable=False)
+    camera_type = db.Column(db.String, nullable=False)
+    client_ip = db.Column(db.String, nullable=False)
+    camera_url = db.Column(db.String, nullable=False)
+    barcode = db.Column(db.String, nullable=False)
+    timestamp = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    def __repr__(self) -> str:  # pragma: no cover - representation only
+        return f"<Scan {self.id} {self.barcode}>"
 
 @app.route('/')
 def hello():
     return 'Hello, World from Flask!'
 
 
-@app.route('/scan', methods=['POST'])
-def scan():
+bp = Blueprint("scan", __name__)
+
+
+@bp.route("/api/scan", methods=["POST"])
+def ingest_scan() -> tuple:
+    """Ingest scan data from cameras."""
     data = request.get_json(force=True, silent=True) or {}
-    print(f"Received payload: {data}")
-    return jsonify({'status': 'ok'})
+    try:
+        timestamp = data.get("timestamp")
+        if timestamp:
+            timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        else:
+            timestamp = datetime.utcnow()
+        scan = Scan(
+            camera_name=data["camera_name"],
+            area=data["area"],
+            camera_type=data["camera_type"],
+            client_ip=data["client_ip"],
+            camera_url=data["camera_url"],
+            barcode=data["barcode"],
+            timestamp=timestamp,
+        )
+    except Exception as exc:  # pragma: no cover - input errors
+        return jsonify({"error": f"Invalid payload: {exc}"}), 400
+
+    db.session.add(scan)
+    db.session.commit()
+    return jsonify({"status": "success", "id": scan.id})
+
+
+@bp.route("/scans")
+def list_scans() -> str:
+    """Render a table with all scans."""
+    scans = Scan.query.order_by(Scan.timestamp.desc()).all()
+    return render_template("scans.html", scans=scans)
+
+
+@bp.route("/scans/<int:scan_id>/edit", methods=["GET", "POST"])
+def edit_scan(scan_id: int):
+    """Edit an existing scan record."""
+    scan = Scan.query.get_or_404(scan_id)
+    if request.method == "POST":
+        try:
+            scan.camera_name = request.form["camera_name"]
+            scan.area = request.form["area"]
+            scan.camera_type = request.form["camera_type"]
+            scan.client_ip = request.form["client_ip"]
+            scan.camera_url = request.form["camera_url"]
+            scan.barcode = request.form["barcode"]
+            scan.timestamp = datetime.fromisoformat(
+                request.form["timestamp"].replace("Z", "+00:00")
+            )
+            db.session.commit()
+            flash("Scan updated", "success")
+            return redirect(url_for("scan.list_scans"))
+        except Exception as exc:  # pragma: no cover - input errors
+            flash(f"Failed to update scan: {exc}", "danger")
+    return render_template("scan_edit.html", scan=scan)
+
+
+@bp.route("/scans/<int:scan_id>/delete", methods=["POST"])
+def delete_scan(scan_id: int):
+    """Delete a scan record."""
+    scan = Scan.query.get_or_404(scan_id)
+    db.session.delete(scan)
+    db.session.commit()
+    flash("Scan deleted", "success")
+    return redirect(url_for("scan.list_scans"))
+
+
+app.register_blueprint(bp)
 
 if __name__ == '__main__':
+    with app.app_context():
+        db.create_all()
     app.run(host='0.0.0.0', port=5000)

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -1,1 +1,3 @@
 Flask==3.1.1
+Flask-SQLAlchemy==3.1.1
+Flask-Cors==4.0.0

--- a/Server/templates/base.html
+++ b/Server/templates/base.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>WareEye</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  </head>
+  <body>
+    <div class="container mt-4">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+          <div class="alert alert-{{ category }}">{{ message }}</div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/Server/templates/scan_edit.html
+++ b/Server/templates/scan_edit.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Edit Scan {{ scan.id }}</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Camera Name</label>
+    <input type="text" name="camera_name" class="form-control" value="{{ scan.camera_name }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Area</label>
+    <input type="text" name="area" class="form-control" value="{{ scan.area }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Camera Type</label>
+    <input type="text" name="camera_type" class="form-control" value="{{ scan.camera_type }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Client IP</label>
+    <input type="text" name="client_ip" class="form-control" value="{{ scan.client_ip }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Camera URL</label>
+    <input type="text" name="camera_url" class="form-control" value="{{ scan.camera_url }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Barcode</label>
+    <input type="text" name="barcode" class="form-control" value="{{ scan.barcode }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Timestamp (ISO 8601)</label>
+    <input type="text" name="timestamp" class="form-control" value="{{ scan.timestamp.isoformat() }}" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Save Changes</button>
+  <a href="{{ url_for('scan.list_scans') }}" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/Server/templates/scans.html
+++ b/Server/templates/scans.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Scans</h1>
+<table class="table table-bordered table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Camera Name</th>
+      <th>Area</th>
+      <th>Camera Type</th>
+      <th>Client IP</th>
+      <th>Camera URL</th>
+      <th>Barcode</th>
+      <th>Timestamp</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for scan in scans %}
+    <tr>
+      <td>{{ scan.id }}</td>
+      <td>{{ scan.camera_name }}</td>
+      <td>{{ scan.area }}</td>
+      <td>{{ scan.camera_type }}</td>
+      <td>{{ scan.client_ip }}</td>
+      <td>{{ scan.camera_url }}</td>
+      <td>{{ scan.barcode }}</td>
+      <td>{{ scan.timestamp }}</td>
+      <td>
+        <a href="{{ url_for('scan.edit_scan', scan_id=scan.id) }}" class="btn btn-sm btn-primary">Edit</a>
+        <form method="post" action="{{ url_for('scan.delete_scan', scan_id=scan.id) }}" style="display:inline;" onsubmit="return confirm('Delete this scan?');">
+          <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Scan data model using SQLAlchemy
- create API endpoint for `/api/scan`
- list, edit, and delete scans via new web pages
- set up bootstrap-based templates for flash messages
- include required dependencies

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -r Server/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687c1319ed408327abaf19bd6583d446