### PR TITLE
Add filtering and pagination to scans

### DIFF
--- a/Server/models.py
+++ b/Server/models.py
@@ -7,13 +7,13 @@ class Scan(db.Model):
     """Database model for a scan event."""
 
     id = db.Column(db.Integer, primary_key=True)
-    camera_name = db.Column(db.String, nullable=False)
-    area = db.Column(db.String, nullable=False)
+    camera_name = db.Column(db.String, nullable=False, index=True)
+    area = db.Column(db.String, nullable=False, index=True)
     camera_type = db.Column(db.String, nullable=False)
     client_ip = db.Column(db.String, nullable=False)
     camera_url = db.Column(db.String, nullable=False)
-    barcode = db.Column(db.String, nullable=False)
-    timestamp = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    barcode = db.Column(db.String, nullable=False, index=True)
+    timestamp = db.Column(db.DateTime, nullable=False, index=True, default=datetime.utcnow)
 
     def __repr__(self) -> str:  # pragma: no cover - representation only
         return f"<Scan {self.id} {self.barcode}>"

--- a/Server/templates/scans.html
+++ b/Server/templates/scans.html
@@ -1,6 +1,29 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Scans</h1>
+
+<form method="get" class="row g-3 mb-4" action="{{ url_for('scan.list_scans') }}">
+  <div class="col-md-2">
+    <input type="text" name="barcode" class="form-control" placeholder="Barcode" value="{{ args.get('barcode', '') }}">
+  </div>
+  <div class="col-md-2">
+    <input type="text" name="area" class="form-control" placeholder="Location/Area" value="{{ args.get('area', '') }}">
+  </div>
+  <div class="col-md-2">
+    <input type="text" name="camera_name" class="form-control" placeholder="Camera Name" value="{{ args.get('camera_name', '') }}">
+  </div>
+  <div class="col-md-2">
+    <input type="date" name="start_date" class="form-control" value="{{ args.get('start_date', '') }}">
+  </div>
+  <div class="col-md-2">
+    <input type="date" name="end_date" class="form-control" value="{{ args.get('end_date', '') }}">
+  </div>
+  <div class="col-md-2 d-flex">
+    <button type="submit" class="btn btn-primary me-2">Search</button>
+    <a href="{{ url_for('scan.list_scans') }}" class="btn btn-secondary">Clear</a>
+  </div>
+</form>
+
 <table class="table table-bordered table-striped">
   <thead>
     <tr>
@@ -16,7 +39,8 @@
     </tr>
   </thead>
   <tbody>
-    {% for scan in scans %}
+    {% if scans.items %}
+    {% for scan in scans.items %}
     <tr>
       <td>{{ scan.id }}</td>
       <td>{{ scan.camera_name }}</td>
@@ -34,6 +58,24 @@
       </td>
     </tr>
     {% endfor %}
+    {% else %}
+    <tr>
+      <td colspan="9" class="text-center">No scans match your criteria.</td>
+    </tr>
+    {% endif %}
   </tbody>
 </table>
+
+<nav>
+  <ul class="pagination">
+    <li class="page-item {% if not scans.has_prev %}disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('scan.list_scans', page=scans.prev_num, **args) }}">Prev</a>
+    </li>
+    <li class="page-item disabled"><span class="page-link">Page {{ scans.page }} of {{ scans.pages }}</span></li>
+    <li class="page-item {% if not scans.has_next %}disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('scan.list_scans', page=scans.next_num, **args) }}">Next</a>
+    </li>
+  </ul>
+</nav>
+
 {% endblock %}


### PR DESCRIPTION
## Summary
- index key fields on the `Scan` model for faster queries
- implement filter and pagination logic in `/scans`
- show a filter form and pagination controls in `scans.html`

## Testing
- `python -m compileall -q Server`

------
https://chatgpt.com/codex/tasks/task_e_687eba680dc88327a45d8b3ad2113f53