### PR TITLE
Add Tailwind navigation header

### DIFF
--- a/Server/templates/base.html
+++ b/Server/templates/base.html
@@ -3,9 +3,40 @@
   <head>
     <meta charset="utf-8">
     <title>WareEye</title>
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   </head>
-  <body>
+  <body class="bg-gray-100">
+    <nav class="bg-gray-900 text-gray-100">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex items-center justify-between h-16">
+          <div class="flex items-center">
+            <a href="{{ url_for('scan.hello') }}" class="text-xl font-semibold">WareEye</a>
+            <div class="hidden md:block ml-10 space-x-4">
+              <a href="{{ url_for('scan.hello') }}" class="px-3 py-2 rounded-md text-sm font-medium {% if request.endpoint == 'scan.hello' %}bg-gray-800 text-white{% else %}text-gray-300 hover:bg-gray-800 hover:text-white{% endif %}">Home</a>
+              <a href="{{ url_for('scan.list_scans') }}" class="px-3 py-2 rounded-md text-sm font-medium {% if request.endpoint == 'scan.list_scans' %}bg-gray-800 text-white{% else %}text-gray-300 hover:bg-gray-800 hover:text-white{% endif %}">Scans</a>
+              <a href="{{ url_for('scan.list_destination_codes') }}" class="px-3 py-2 rounded-md text-sm font-medium {% if request.endpoint == 'scan.list_destination_codes' %}bg-gray-800 text-white{% else %}text-gray-300 hover:bg-gray-800 hover:text-white{% endif %}">Destination Codes</a>
+              <a href="{{ url_for('scan.list_dock_doors') }}" class="px-3 py-2 rounded-md text-sm font-medium {% if request.endpoint == 'scan.list_dock_doors' %}bg-gray-800 text-white{% else %}text-gray-300 hover:bg-gray-800 hover:text-white{% endif %}">Dock Doors</a>
+              <a href="#" class="px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:bg-gray-800 hover:text-white">Stream / Live Feed</a>
+            </div>
+          </div>
+          <div class="md:hidden">
+            <button id="mobile-menu-button" class="text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white">
+              <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div id="mobile-menu" class="hidden md:hidden px-2 pt-2 pb-3 space-y-1">
+        <a href="{{ url_for('scan.hello') }}" class="block px-3 py-2 rounded-md text-base font-medium {% if request.endpoint == 'scan.hello' %}bg-gray-800 text-white{% else %}text-gray-300 hover:bg-gray-800 hover:text-white{% endif %}">Home</a>
+        <a href="{{ url_for('scan.list_scans') }}" class="block px-3 py-2 rounded-md text-base font-medium {% if request.endpoint == 'scan.list_scans' %}bg-gray-800 text-white{% else %}text-gray-300 hover:bg-gray-800 hover:text-white{% endif %}">Scans</a>
+        <a href="{{ url_for('scan.list_destination_codes') }}" class="block px-3 py-2 rounded-md text-base font-medium {% if request.endpoint == 'scan.list_destination_codes' %}bg-gray-800 text-white{% else %}text-gray-300 hover:bg-gray-800 hover:text-white{% endif %}">Destination Codes</a>
+        <a href="{{ url_for('scan.list_dock_doors') }}" class="block px-3 py-2 rounded-md text-base font-medium {% if request.endpoint == 'scan.list_dock_doors' %}bg-gray-800 text-white{% else %}text-gray-300 hover:bg-gray-800 hover:text-white{% endif %}">Dock Doors</a>
+        <a href="#" class="block px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-800 hover:text-white">Stream / Live Feed</a>
+      </div>
+    </nav>
     <div class="container mt-4">
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
@@ -16,5 +47,12 @@
       {% endwith %}
       {% block content %}{% endblock %}
     </div>
+    <script>
+      const btn = document.getElementById('mobile-menu-button');
+      const menu = document.getElementById('mobile-menu');
+      btn?.addEventListener('click', () => {
+        menu.classList.toggle('hidden');
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- include Tailwind CSS
- add dark navigation header with links
- include mobile menu toggle script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68817b64f8808327a01031671531821b