### PR TITLE
Improve docs for running WareEye

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to WareEye
+
+Thank you for your interest in helping improve WareEye! Contributions of all
+sizes are welcome. This project is split into a Python server and client so most
+changes will involve one or both of those components.
+
+## Getting started
+
+1. Fork the repository and clone your fork.
+2. Install the dependencies for the part you want to work on:
+
+   ```bash
+   cd Server
+   pip install -r requirements.txt
+   ```
+
+   and/or
+
+   ```bash
+   cd Client
+   pip install -r requirements.txt
+   ```
+
+3. Run the applications to ensure they start correctly before making changes:
+
+   ```bash
+   python Server/app.py
+   python Client/client.py
+   ```
+
+## Making changes
+
+* Use Python 3.12 or newer.
+* Keep code style consistent with the existing project (we use
+  [black](https://black.readthedocs.io/) for formatting).
+* Include docstrings and comments where helpful.
+* If adding features or fixing bugs, consider adding tests if possible.
+
+## Submitting a pull request
+
+1. Create a new branch in your fork for each set of related changes.
+2. Push the branch and open a pull request against the `main` branch of this
+   repository.
+3. Provide a clear description of what you changed and why.
+4. Ensure `pip install -r requirements.txt` succeeds for both `Server` and
+   `Client` before submitting.
+
+We will review your pull request and work with you to get it merged. Thanks for
+helping make WareEye better!

--- a/README.md
+++ b/README.md
@@ -1,27 +1,40 @@
 # WareEye
 
-## Usage
+WareEye is a basic barcode scanning system made up of two Python applications:
 
-### Server
+* **Server** – a small Flask app that stores scan records and provides a simple
+  web interface to browse them.
+* **Client** – a webcam utility that detects barcodes or QR codes and sends the
+  results to the server.
+
+## Running the server
 
 ```bash
 cd Server
+pip install -r requirements.txt
 python app.py
 ```
 
-### Client
+The server listens on port `5000` by default and creates an `app.db` SQLite
+database in the `Server` directory.
+
+## Running the client
 
 ```bash
 cd Client
+pip install -r requirements.txt
 python client.py
 ```
 
-The client prompts for camera details and streams video while scanning for barcodes.
+The client prompts for camera information, opens the webcam or RTSP stream and
+continually scans frames for barcodes. Detected values are sent to the server.
 
-## Community and Contributing
+## How you can help
 
-WareEye is an open source project and we’re looking for enthusiastic contributors.
-Whether you’re a fan of clever hardware (like a comfy recliner) or you just want to
-build better barcode scanning tools, your help is welcome. Fork this repo, open
-issues, or send pull requests to become a collaborator and shape WareEye with us.
+WareEye is very much a work in progress. We would love help with:
 
+* improving detection accuracy and performance
+* polishing the web UI and dashboard
+* packaging the project (e.g. Docker, Windows binaries)
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get involved.


### PR DESCRIPTION
## Summary
- rewrite README with a clearer project overview and steps for running the server/client
- add CONTRIBUTING.md with guidelines for new contributors

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688198e965588327b638328bcdba72c3