### PR TITLE
Add QR code PDF generation for OLPN labels

### DIFF
--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -1,3 +1,5 @@
 Flask==3.1.1
 Flask-SQLAlchemy==3.1.1
 Flask-Cors==4.0.0
+qrcode==7.4.2
+reportlab==4.1.0

--- a/Server/templates/olpn_labels.html
+++ b/Server/templates/olpn_labels.html
@@ -35,6 +35,7 @@
       <td>{{ label.destination.code }}</td>
       <td>{{ label.created_at }}</td>
       <td>
+        <a href="{{ url_for('scan.olpn_label_pdf', label_id=label.id) }}" class="btn btn-sm btn-secondary">PDF</a>
         <a href="{{ url_for('scan.edit_olpn_label', label_id=label.id) }}" class="btn btn-sm btn-primary">Edit</a>
         <form method="post" action="{{ url_for('scan.delete_olpn_label', label_id=label.id) }}" style="display:inline;" onsubmit="return confirm('Delete this label?');">
           <button type="submit" class="btn btn-sm btn-danger">Delete</button>


### PR DESCRIPTION
## Summary
- allow creation of a PDF containing a QR barcode for each OLPN label
- add download button in the OLPN Labels table
- include `qrcode` and `reportlab` dependencies

## Testing
- `python -m py_compile Server/routes.py Server/app.py Server/models.py`
- `find . -name '*.py' | xargs python -m py_compile`
- `python -m pip install -r Server/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6884102bdd5c8327b8215f0b06412020